### PR TITLE
Email invites

### DIFF
--- a/client/components/searchResults.js
+++ b/client/components/searchResults.js
@@ -23,16 +23,8 @@ class SearchResults extends Component {
 
     this.props.actions.chooseSearchResult(result);
 
-<<<<<<< 77a9bc76a0113f7d2efc85af110407db0d4d1ca1
-    axios.get(`${ROOT_URL}/send-email?competitor=${result.login}`);
-=======
     // SEND EMAIL
-    // ?from=${this.props.user.username}
-    axios.get(`${ROOT_URL}/send-email?competitor=${result.login}`)
-      .then(response => {
-        console.log('email sent!');
-      });
->>>>>>> (feat) For email invitations, look up competitor email in database, otherwise fetch it from Github
+    axios.get(`${ROOT_URL}/send-email?user=${this.props.user.username}&competitor=${result.login}&competitor_id=${result.id}`)
 
     browserHistory.push(`compete/choose-repo/${result.login}`);
 

--- a/client/components/searchResults.js
+++ b/client/components/searchResults.js
@@ -23,7 +23,7 @@ class SearchResults extends Component {
 
     this.props.actions.chooseSearchResult(result);
 
-    axios.get(`${ROOT_URL}/send-email`);
+    axios.get(`${ROOT_URL}/send-email?competitor=${result.login}`);
 
     browserHistory.push(`compete/choose-repo/${result.login}`);
 

--- a/client/components/searchResults.js
+++ b/client/components/searchResults.js
@@ -23,7 +23,16 @@ class SearchResults extends Component {
 
     this.props.actions.chooseSearchResult(result);
 
+<<<<<<< 77a9bc76a0113f7d2efc85af110407db0d4d1ca1
     axios.get(`${ROOT_URL}/send-email?competitor=${result.login}`);
+=======
+    // SEND EMAIL
+    // ?from=${this.props.user.username}
+    axios.get(`${ROOT_URL}/send-email?competitor=${result.login}`)
+      .then(response => {
+        console.log('email sent!');
+      });
+>>>>>>> (feat) For email invitations, look up competitor email in database, otherwise fetch it from Github
 
     browserHistory.push(`compete/choose-repo/${result.login}`);
 

--- a/client/components/searchResults.js
+++ b/client/components/searchResults.js
@@ -5,19 +5,26 @@ import { bindActionCreators } from 'redux';
 import actions from './../actions/ActionCreators';
 import { SearchOptions } from './index';
 
+// import axios, define root URL -- for email sending
+import axios from 'axios';
+const ROOT_URL = 'http://127.0.0.1:8000';
 
 class SearchResults extends Component {
   constructor(props) {
     super(props);
   }
+
   compete(e, result) {
     e.preventDefault();
 
     // HARDCODE DATA IN REDUX STORE FOR CHART (TEMPORARY)
     this.props.actions.addCompetitorData([20, 11]);
     this.props.actions.addDailyCompetitorData([[5, 4, 2, 7, 3, 6, 8], [2, 3, 5, 9, 7, 2, 3]]);
-    // END HARDCODE
+
     this.props.actions.chooseSearchResult(result);
+
+    axios.get(`${ROOT_URL}/send-email`);
+
     browserHistory.push(`compete/choose-repo/${result.login}`);
 
   }
@@ -30,7 +37,7 @@ class SearchResults extends Component {
           <input type="button" value="compete" onClick={(e) => { this.compete(e, result) }} />
         </div>
       )
-    
+
   }
 
   render() {
@@ -50,9 +57,9 @@ class SearchResults extends Component {
         return <div></div>
       }
     } else {
-     return <div></div> 
+     return <div></div>
     }
-  } 
+  }
 }
 
 const mapStateToProps = (state) => {

--- a/client/components/searchResults.js
+++ b/client/components/searchResults.js
@@ -40,6 +40,17 @@ class SearchResults extends Component {
 
   }
 
+  getResult(result) {
+      return (
+        <div className="user-result-container">
+          <img className="user-avatar-1" src={result.avatar_url} />
+          <h2>{result.login}</h2>
+          <input type="button" value="compete" onClick={(e) => { this.compete(e, result) }} />
+        </div>
+      )
+
+  }
+
   render() {
     if (this.props.searchResults.length > 0) {
       const searchResults = this.props.searchResults[0].items;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "redux-actions": "^0.9.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
+<<<<<<< d039cf654e486b96138f24afcf426c5196cddc92
     "socket.io": "^1.4.6",
+=======
+>>>>>>> Add sendgrid email send capability
     "sendgrid": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "redux-actions": "^0.9.1",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.0.1",
-    "socket.io": "^1.4.6"
+    "socket.io": "^1.4.6",
+    "sendgrid": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",

--- a/server/config/sendGridKey.js
+++ b/server/config/sendGridKey.js
@@ -1,0 +1,3 @@
+module.exports = {
+  key: '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'
+}

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -16,7 +16,7 @@ exports.retrieveAllUsers = function(req, res) {
 };
 
 // POST at /api/v1/users
-exports.addUser = function(req, res) {  
+exports.addUser = function(req, res) {
   var dbTimestamp = pgp.as.date(new Date());
   db.any('INSERT INTO users (username, email, id, created_ga) ' +
     'VALUES ($1, $2, $3, $4)',
@@ -42,12 +42,13 @@ exports.retrieveUser = function(req, res) {
 // PATCH at '/api/v1/users/:id' to update user with current GitHub data
 exports.updateUser = function(req, res) {
   var queryId = req.params.id;
-  var username = req.body.username;
+  // invitationSender.js uses req.headers
+  var username = req.headers.username || req.body.username;
   var dbTimestamp = pgp.as.date(new Date());
   console.log('in PATCH, username: ', username);
-  
+
   // HELPER FUNCTIONS
-  
+
   // get user info from GitHub
   var getUserFromGitHub = function(username, callback) {
     var options = {
@@ -66,13 +67,13 @@ exports.updateUser = function(req, res) {
       }
     });
   };
-  
+
   // if user exists, update their info; otherwise, add them
   // this is an 'upsert' - it will insert a record if it does not exist, or update it if it exists
   var upsertUser = function(body) {
     db.one('INSERT INTO $1~ AS $2~ ($3~, $4~, $5~, $6~, $7~, $8~, $9~) ' +
       'VALUES ($10, $11, $12, $13, $14, $15, $16) ' +
-      'ON CONFLICT ($3~) ' + 
+      'ON CONFLICT ($3~) ' +
       'DO UPDATE SET ($17~, $5~, $6~, $7~, $8~, $9~) = ($11, $12, $13, $14, $15, $16) ' +
       'WHERE $2~.$3~ = $10 ' +
       'RETURNING *',
@@ -91,7 +92,7 @@ exports.updateUser = function(req, res) {
       }
     });
   };
-  
+
   // CALL HELPERS
   getUserFromGitHub(username, upsertUser);
 };
@@ -112,4 +113,4 @@ exports.deleteUser = function(req, res) {
         res.status(500).send('Error searching database for user');
       }
     });
-};  
+};

--- a/server/db/database.js
+++ b/server/db/database.js
@@ -34,6 +34,6 @@ db.tx(t=> t.one(sql.test)
   })
   .finally(pgp.end)
 );
-  
+
 exports.db = db;
 exports.pgp = pgp;

--- a/server/helpers/invitationSender.js
+++ b/server/helpers/invitationSender.js
@@ -1,22 +1,78 @@
-var SEND_GRID_API = require('./../../server/config/sendGridKey');
-var sendgrid  = require('sendgrid')(SEND_GRID_API.key);
+const db = require('../db/database.js').db;
+const pgp = require('../db/database.js').pgp;
+const SEND_GRID_API = require('./../../server/config/sendGridKey');
+const sendgrid  = require('sendgrid')(SEND_GRID_API.key);
+const request = require('request');
+
+var competitorEmail;
+
+// @ISSUE: seems to be getting called twice (two emails, two 'in api' & json console logs)
+// @ISSUE: also seem to be getting rejected promises in console (may be related to twice-sending)
+// @TODO: add email to database in the cases that I fetch it
+
+var sendEmail = (competitorEmail) => {
+
+  var email     = new sendgrid.Email({
+    to:       competitorEmail,
+    from:     'gitachieve@gmail.com',
+    subject:  'Message from SendGrid!',
+    text:     'Hello from SendGrid'
+  });
+
+  sendgrid.send(email, function(err, json) {
+    if (err) { console.error('sendGrid error:', err); }
+    console.log('sendGrid sent an email (in invitationSender.js) with:', json);
+  });
+}
+
+
+var getEmail = (user) => {
+  var options = {
+    url: `https://api.github.com/users/${user}`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': user
+    }
+  };
+  return request(options, (error, response, body) => {
+    if (error) {
+      console.error('error fetching competitor email from Github, in invitationSender.js: ', error);
+    } else {
+      competitorEmail = JSON.parse(body).email;
+      sendEmail(competitorEmail);
+    }
+  });
+}
+
 
 module.exports = (app) => {
+
   app.get('/send-email', (req, res) => {
 
-    var email     = new sendgrid.Email({
-      to:       'adamrgisom@gmail.com',
-      from:     'gitachieve@gmail.com',
-      subject:  'Subject goes here',
-      text:     'Hello world'
+    var competitor = req.query.competitor;
+
+    db.one(
+      'SELECT u.id, u.username, u.email ' +
+      'FROM users u ' +
+      'WHERE u.username = ($1)',
+      competitor
+    )
+    .then(data => {
+      competitorEmail = data.email;
+
+      // if competitor's email is not in the database, get it
+      if (!competitorEmail) {
+        getEmail(competitor);
+        // ... and add it to the database
+
+      }
+
+      // otherwise send email immediately
+      else {
+        sendEmail(competitorEmail);
+      }
+
     });
-
-    console.log('in /api/v1/send-email');
-
-    sendgrid.send(email, function(err, json) {
-      if (err) { return console.error(err); }
-      console.log(json);
-    });
-
-  })
+  });
 };

--- a/server/helpers/invitationSender.js
+++ b/server/helpers/invitationSender.js
@@ -1,0 +1,22 @@
+var SEND_GRID_API = require('./../../server/config/sendGridKey');
+var sendgrid  = require('sendgrid')(SEND_GRID_API.key);
+
+module.exports = (app) => {
+  app.get('/send-email', (req, res) => {
+
+    var email     = new sendgrid.Email({
+      to:       'adamrgisom@gmail.com',
+      from:     'gitachieve@gmail.com',
+      subject:  'Subject goes here',
+      text:     'Hello world'
+    });
+
+    console.log('in /api/v1/send-email');
+
+    sendgrid.send(email, function(err, json) {
+      if (err) { return console.error(err); }
+      console.log(json);
+    });
+
+  })
+};

--- a/server/helpers/invitationSender.js
+++ b/server/helpers/invitationSender.js
@@ -1,12 +1,10 @@
-// @ISSUE: may be getting called twice (two 'in api' & json console logs)
-// @ISSUE: also seem to be getting rejected promises in console (may be related to twice-sending)
-// @TODO: add email to database in the cases that I fetch it
 // @TODO: add link that if clicked notifies the challenger their challenge was accepted
 const request = require('request');
 const db = require('../db/database.js').db;
 const pgp = require('../db/database.js').pgp;
 const SEND_GRID_API = require('./../../server/config/sendGridKey');
 const sendgrid  = require('sendgrid')(SEND_GRID_API.key);
+<<<<<<< 77a9bc76a0113f7d2efc85af110407db0d4d1ca1
 const CALLBACKHOST = require('../config/config-settings').CALLBACKHOST;
 
 var competitorEmail;

--- a/server/helpers/invitationSender.js
+++ b/server/helpers/invitationSender.js
@@ -4,7 +4,6 @@ const db = require('../db/database.js').db;
 const pgp = require('../db/database.js').pgp;
 const SEND_GRID_API = require('./../../server/config/sendGridKey');
 const sendgrid  = require('sendgrid')(SEND_GRID_API.key);
-<<<<<<< 77a9bc76a0113f7d2efc85af110407db0d4d1ca1
 const CALLBACKHOST = require('../config/config-settings').CALLBACKHOST;
 
 var competitorEmail;

--- a/server/helpers/invitationSender.js
+++ b/server/helpers/invitationSender.js
@@ -1,4 +1,6 @@
+// @ISSUE: possible issue, pay attention to whether multiple email requests are sent
 // @TODO: add link that if clicked notifies the challenger their challenge was accepted
+
 const request = require('request');
 const db = require('../db/database.js').db;
 const pgp = require('../db/database.js').pgp;
@@ -18,7 +20,7 @@ var sendEmail = (competitorEmail) => {
     to:     competitorEmail,
     from:   'gitachieve@gmail.com',
     subject: `${user} wants to compete with you on GitAchieve`,
-    text:   "You've been challenged by ${user} on GitAchieve!\nAccept the invitation"
+    html:   `<h2>You\'ve received a challenge on GitAchieve!</h2><p>Github user ${user} wants to compete with you, meaning you each select one repo and see who can make more commits within the competition timeframe!</p><p><a>Create an account</a> at gitachieve.com in seconds with Github login.</p>`
   });
 
   sendgrid.send (email, function (err, json) {

--- a/server/server.js
+++ b/server/server.js
@@ -11,13 +11,14 @@ const app = express();
 require('./helpers/middleware.js')(app);
 require('./helpers/auth.js')(app);
 require('./helpers/userGHFetcher')(app);
+require('./helpers/invitationSender')(app);
 
 // Routers
 const userRouter = require('./routers/userRouter.js');
 const orgRouter = require('./routers/orgRouter.js');
 
 // Use routers for specific paths
-app.use('/api/v1/users', userRouter); 
+app.use('/api/v1/users', userRouter);
 app.use('/api/v1/orgs', orgRouter);
 
 app.use('/static', express.static(__dirname + '/../client'));


### PR DESCRIPTION
Use SendGrid to easily send email invitations when you click the compete button. 
If the competitor's email is not in the users table, it will grab it from Github, then patch the database with it.
