### PR TITLE
(Fix) Deployment cleanup - refactor gulpfile.js, .travis.yml, and various configs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,29 @@ language: node_js
 node_js:
   - "6"
   - "5"
-  - "4"
   - "iojs"
 before_script:
   - npm install -g jasmine-node
   - npm install -g gulp
+  - npm install gulp
+  - npm install gulp-babel
+  - npm install gulp-clean
+  - npm install gulp-concat
+  - npm install gulp-env
+  - npm install gulp-eslint
+  - npm install gulp-filesize
+  - npm install gulp-mocha
+  - npm install gulp-mocha-phantomjs
+  - npm install gulp-nodemon
+  - npm install gulp-rename
+  - npm install gulp-sass
+  - npm install gulp-shell
+  - npm install gulp-uglify
+  - npm install gulp-util
+  - npm install webpack-stream
+  - echo '{"NODE_ENV":"production"}'> ./server/config/.env.json
+  - npm run serve
+  
 script: 'gulp test'
 sudo: false
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ before_script:
   - npm install gulp-uglify
   - npm install gulp-util
   - npm install webpack-stream
-  - echo '{"NODE_ENV":"production"}'> ./server/config/.env.json
+  - echo '{"NODE_ENV":"production","PORT": 8000}' > ./server/config/.env.json
+  - echo 'exports.PORT = process.env.PORT || 8000; exports.CALLBACKHOST = (exports.PORT === 8000) ? "http://127.0.0.1:8000" : "http://gitachieve.com"; exports.HOST = (exports.PORT === 8000) ? "127.0.0.1" : "gitachieve.com";' > ./server/config/config-settings.js
+  - echo ' ' > ./server/config/github.config.js
+  - echo ' ' > ./server/config/sendGridKey.js
   - npm run serve
   
 script: 'gulp test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_script:
   - npm install gulp-uglify
   - npm install gulp-util
   - npm install webpack-stream
-  - echo '{"NODE_ENV":"production","PORT": 8000}' > ./server/config/.env.json
-  - echo 'exports.PORT = process.env.PORT || 8000; exports.CALLBACKHOST = (exports.PORT === 8000) ? "http://127.0.0.1:8000" : "http://gitachieve.com"; exports.HOST = (exports.PORT === 8000) ? "127.0.0.1" : "gitachieve.com";' > ./server/config/config-settings.js
+  - echo '{"NODE_ENV":"production"}' > ./server/config/.env.json
   - echo ' ' > ./server/config/github.config.js
   - echo ' ' > ./server/config/sendGridKey.js
   - npm run serve

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - echo '{"NODE_ENV":"production"}' > ./server/config/.env.json
   - echo ' ' > ./server/config/github.config.js
   - echo ' ' > ./server/config/sendGridKey.js
+  - echo ' ' > ./server/config/dbConfig.js
   - npm run serve
   
 script: 'gulp test'

--- a/client/chartmakers/cumulativeChart.js
+++ b/client/chartmakers/cumulativeChart.js
@@ -105,7 +105,9 @@ module.exports = (data) => {
       .enter()
         .append('text')
         .attr('x', (d, i) => xScale(users[i]) + barWidth/2)
-        .attr('y', (d) => yScale(d) + 16)
+        .attr('y', (d) => {
+          return d < mostCommits/20 ? yScale(d) - 11 : yScale(d) + 16;
+        })
         .attr('text-anchor', 'middle')
         .text((d) => d > 0 ? d.toString() : '')
         .attr('font-weight', '100')

--- a/client/components/competitorCards/acceptedCompetitorCard.js
+++ b/client/components/competitorCards/acceptedCompetitorCard.js
@@ -35,19 +35,24 @@ class AcceptedCompetitorCard extends Component {
   }
 
   componentWillUnmount() {
-    // clearInterval(window.interval);
+    clearInterval(window.interval);
   }
 
   competitionUpdateInterval(c) {
-    // clearInterval(window.interval);
-    // window.interval = setInterval(() => {
-    //   console.log('primary user id2', c.primary_user_id);
-    //   console.log('secondary_user_id2', c.secondary_user_id);
-    //   axios.patch(`${ROOT_URL}/api/v1/users/${c.primary_user_id}/${c.secondary_user_id}/update`, {
-    //     token: localStorage.token
-    //   });
-    //   this.setState({toggleUpdate: !this.state.toggleUpdate});
-    // }, 10000);
+    clearInterval(window.interval);
+    window.interval = setInterval(() => {
+      // console.log('primary user id2', c.primary_user_id);
+      // console.log('secondary_user_id2', c.secondary_user_id);
+      axios.patch(
+        `${ROOT_URL}/api/v1/users/${c.primary_user_id}/${c.secondary_user_id}/update`, 
+        {
+          token: localStorage.token, 
+          primaryUsername: this.props.user.username,
+          secondaryUsername: this.state.username
+      });
+      
+      this.setState({toggleUpdate: !this.state.toggleUpdate});
+    }, 30000);
   }
 
   handleAccept(c) {
@@ -71,6 +76,8 @@ class AcceptedCompetitorCard extends Component {
     var userRepo, competitorRepo;
     var data, totalCommitsForUser, totalCommitsForComp;
     var dailyData, dailyUserData, dailyCompetitorData;
+
+    this.competitionUpdateInterval(c);
 
     axios({
       method: 'get',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,11 +93,13 @@ gulp.task('env', function() {
 gulp.task('run', ['build', 'env'], function() {
   if (envConfig.NODE_ENV !== 'production') {
     nodemon({
-      script: './server/server.js'
+      script: './server/server.js',
+      quiet: true
     });
   } else {
     nodemon({
-      script: './dist/server-all.min.js'
+      script: './dist/server-all.min.js',
+      quiet: true
     });
   }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,46 +1,83 @@
 // Include Gulp
-var gulp = require('gulp');
+const gulp = require('gulp');
 
 // Include Our Plugins
-var jshint = require('gulp-jshint');
-var sass = require('gulp-sass');
-var concat = require('gulp-concat');
-var uglify = require('gulp-uglify');
-var rename = require('gulp-rename');
-var mocha = require('gulp-mocha');
-var util = require('gulp-util');
-var shell = require('gulp-shell');
-var webpack = require('webpack-stream');
-var mochaPhantomJs = require('gulp-mocha-phantomjs');
+const babel = require('gulp-babel');
+const clean = require('gulp-clean');
+const env = require('gulp-env');
+const eslint = require('gulp-eslint');
+const sass = require('gulp-sass');
+const concat = require('gulp-concat');
+const uglify = require('gulp-uglify');
+const rename = require('gulp-rename');
+const mocha = require('gulp-mocha');
+const nodemon = require('gulp-nodemon');
+const util = require('gulp-util');
+const shell = require('gulp-shell');
+const webpack = require('webpack-stream');
+const webpackOptions = require('./webpack.config.production.js');
+const mochaPhantomJs = require('gulp-mocha-phantomjs');
+
+const paths = {
+  scripts: ['server/**/*.js']
+};
+
+const envConfig = require('./server/config/.env.json');
 
 // Lint Task
 gulp.task('lint', function() {
   return gulp.src(['./client/**/*.js', './server/**/*.js'], {base: '.'})
-    .pipe(jshint({esnext: true}))
-    .pipe(jshint.reporter('default'));
+    .pipe(babel({
+      presets: ['es2015']
+    }))
+    .pipe(eslint({
+      config: './test/hrStyleGuide.json'
+    }))
+    .pipe(eslint.format())
+    .on('error', util.log);
 });
 
 // Test Task
 gulp.task('test', shell.task([
   'mocha test/client/.setup.js test/client',
-  'jasmine-node test/server/ --junitreport'
+  'jasmine-node test/server/test_spec.js --junitreport',
 ]));
 
-// Build Task
-gulp.task('build', function() {
-  return gulp.src('client/index.js')
-    .pipe(webpack())
-    .pipe(gulp.dest('dist/'));
+// Clean out previous dist folder
+gulp.task('clean', function () {  
+  return gulp.src('dist', {read: false})
+    .pipe(clean());
 });
 
-// Concatenate & Minify JS Task
-gulp.task('scripts', function() {
-  return gulp.src('server/**/*.js')
-    .pipe(concat('all.js'))
+// Concatenate & Uglify client-side JS
+  // 'clean' must finish before this will start
+gulp.task('build-client', ['clean'], function() {
+  return gulp.src('client/index.js')
+    .pipe(webpack(webpackOptions))
+    .pipe(rename('bundle.big.js'))
     .pipe(gulp.dest('dist'))
-    .pipe(rename('all.min.js'))
+    .pipe(babel({
+      presets: ['es2015']
+    }))
+    .pipe(rename('bundle.js'))
     .pipe(uglify())
-    .pipe(gulp.dest('dist/js'));
+    .pipe(gulp.dest('dist'))
+    .on('error', util.log);
+});
+
+// Concatenate & Uglify server-side JS
+  // 'clean' must finish before this will start
+gulp.task('build-server', ['clean'], function() {
+  return gulp.src(paths.scripts)
+    .pipe(babel({
+      presets: ['es2015']
+    }))
+    .pipe(concat('server-all.js'))
+    .pipe(gulp.dest('dist'))
+    .pipe(rename('server-all.min.js'))
+    .pipe(uglify())
+    .pipe(gulp.dest('dist'))
+    .on('error', util.log);
 });
 
 // Watch Files For Changes
@@ -49,9 +86,33 @@ gulp.task('watch', function() {
   // gulp.watch('scss/*.scss', ['sass']);
 });
 
+gulp.task('env', function() {
+  env({
+    file: './server/config/.env.json'
+  });
+});
+
+// if the NODE_ENV is not 'production', use the un-minified server file
+// if 'production', use the minified version
+gulp.task('run', ['build', 'env'], function() {
+  if (envConfig.NODE_ENV !== 'production') {
+    nodemon({
+      script: './server/server.js'
+    });
+  } else {
+    nodemon({
+      script: './dist/server-all.min.js'
+    });
+  }
+});
+
+
 // Default Task
 gulp.task('default', ['lint', 'test', 'watch']);
 
+gulp.task('build', ['clean', 'build-client', 'build-server']);
+
+gulp.task('start', ['build', 'run']);
 
 // Compile Our Sass // Commented out for now since Sass is not integrated yet.
 // gulp.task('sass', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,11 +37,7 @@ gulp.task('lint', function() {
     .on('error', util.log);
 });
 
-// Test Task
-gulp.task('test', shell.task([
-  'mocha test/client/.setup.js test/client',
-  'jasmine-node test/server/test_spec.js --junitreport',
-]));
+
 
 // Clean out previous dist folder
 gulp.task('clean', function () {  
@@ -92,8 +88,8 @@ gulp.task('env', function() {
   });
 });
 
-// if the NODE_ENV is not 'production', use the un-minified server file
-// if 'production', use the minified version
+// if the NODE_ENV is not 'production', use the non-uglified server file
+// if 'production', use the uglified version
 gulp.task('run', ['build', 'env'], function() {
   if (envConfig.NODE_ENV !== 'production') {
     nodemon({
@@ -106,13 +102,24 @@ gulp.task('run', ['build', 'env'], function() {
   }
 });
 
+// Test Task
+gulp.task('runTests', ['run'], shell.task([
+  'mocha test/client/.setup.js test/client',
+  'jasmine-node test/server/test_spec.js --junitreport',
+]));
 
 // Default Task
 gulp.task('default', ['lint', 'test', 'watch']);
 
+// Concatenate / Minify
 gulp.task('build', ['clean', 'build-client', 'build-server']);
 
+// Start Nodemon and run tests
+gulp.task('test', ['run', 'runTests']);
+
+// Build and start Nodemon
 gulp.task('start', ['build', 'run']);
+
 
 // Compile Our Sass // Commented out for now since Sass is not integrated yet.
 // gulp.task('sass', function() {

--- a/server/config/config-settings.js
+++ b/server/config/config-settings.js
@@ -1,3 +1,3 @@
 exports.PORT = process.env.PORT || 8000;
-exports.CALLBACKHOST = (exports.PORT === 8000) ? 'http://127.0.0.1:8000' : 'http://gitachieve.com';
-exports.HOST = (exports.PORT === 8000) ? '127.0.0.1' : 'gitachieve.com';
+exports.CALLBACKHOST = (exports.PORT == 8000) ? 'http://127.0.0.1:8000' : 'http://gitachieve.com';
+exports.HOST = (exports.PORT == 8000) ? '127.0.0.1' : 'gitachieve.com';

--- a/server/db/database.js
+++ b/server/db/database.js
@@ -18,7 +18,15 @@ const DB_LOCAL_CONFIG = {
   password: ''
 };
 
-const db = pgp(DB_LOCAL_CONFIG);
+var dbConfig;
+
+if (process.env.NODE_ENV !== 'production') {
+  dbConfig = DB_LOCAL_CONFIG;
+} else {
+  dbConfig = DB_DEPLOY_CONFIG;
+}
+
+const db = pgp(dbConfig);
 
 db.tx(t=> t.one(sql.test)
   .then((data) => {

--- a/server/helpers/competitionUpdate.js
+++ b/server/helpers/competitionUpdate.js
@@ -1,58 +1,16 @@
 const CALLBACKHOST = require('../config/config-settings').CALLBACKHOST;
 const request = require('request');
 const Promise = require('bluebird');
+const massiveFetch = require('./massiveFetch');
 
 exports.updateCompetition = (req, res) => {
   var primaryid = req.params.primaryid;
+  var primaryUserName = req.body.primaryUsername;
   var secondaryid = req.params.secondaryid;
+  var secondaryUserName = req.body.secondaryUsername;
   var token = req.body.token;
 
-  const updateCommits = (id) => {
-    var options = {
-      url: CALLBACKHOST + '/api/v1/users/' + id + '/commits',
-      method: 'PATCH',
-      form: { token: token },
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      }
-    };
-    request(options, (error, response, body) => {
-      if (error) {
-        console.error('ERROR:', error);
-      } else {
-        console.log('Success in Worker Updating Commits');
-      }
-    });
-  };
-
-  const updateStats = (id) => {
-    console.log('FIRST THEN')
-    var options = {
-      url: CALLBACKHOST + '/api/v1/users/' + id + '/stats',
-      method: 'PATCH',
-      form: { token: token },
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      }
-    };
-    request(options, (error, response, body) => {
-      if (error) {
-        console.error('ERROR:', error);
-      } else {
-        console.log('Success in Worker Updating Stats');
-        updateCommits(id);
-      }
-    });
-  };
-
-  function updateStatsAsync(userid) {
-    console.log('USERID', userid)
-    return new Promise((resolve, reject) => {
-      updateStats(userid, resolve, reject);
-    })
-  }
-
-  updateStatsAsync(primaryid).then(updateStatsAsync(secondaryid))
-
-}
+  massiveFetch(primaryid, primaryUserName, token, null, false);
+  massiveFetch(secondaryid, secondaryUserName, token, null, false);
+};
 

--- a/server/routers/userRouter.js
+++ b/server/routers/userRouter.js
@@ -6,8 +6,6 @@ const statController = require('./../controllers/statController.js');
 const commitController = require('./../controllers/commitController.js');
 const commitStartController = require('./../controllers/commitStartController.js');
 const branchController = require('./../controllers/branchController.js');
-
-
 const update = require('./../helpers/competitionUpdate.js');
 
 // the following routes start from /api/v1/users

--- a/server/server.js
+++ b/server/server.js
@@ -35,7 +35,7 @@ app.get('*', function (req, res) {
 const port = process.env.PORT || 8000;
 const server = http.createServer(app);
 server.listen(port);
-console.log('Server listening in on ', port);
+console.log('GitAchieve server listening on port ' + port + ' in ' + process.env.NODE_ENV + ' mode');
 
 // socket.io
 var io = require('socket.io')(server);

--- a/test/server/test_spec.js
+++ b/test/server/test_spec.js
@@ -1,12 +1,12 @@
 var frisby = require('frisby');
 const CALLBACKHOST = require('../../server/config/config-settings').CALLBACKHOST;
 
-// frisby.create('Get Users')
-//   .get(`${CALLBACKHOST}/api/v1/users`)
-//   .expectStatus(200)
-//   .expectHeader('Content-Type', 'application/json; charset=utf-8')
+frisby.create('Get Users')
+  .get(`${CALLBACKHOST}/api/v1/users`)
+  .expectStatus(200)
+  .expectHeader('Content-Type', 'application/json; charset=utf-8')
 
-// .toss();
+.toss();
 
 // frisby.create('Get User By id')
 //   .get(`${CALLBACKHOST}/api/v1/users/15220759`)


### PR DESCRIPTION
We can now run these Gulp commands:
- `gulp lint` to lint code
- `gulp build` to concatenate / uglify code
- `gulp test` to run nodemon and tests
- `gulp start` to concatenate / uglifuy code and run nodemon

Tests on Travis now start nodemon before they run so they can test the API endpoints
